### PR TITLE
Update teleport_pad.json

### DIFF
--- a/src/main/resources/data/allthemodium/patchouli_books/allthemodium/en_us/entries/dimensions/teleport_pad.json
+++ b/src/main/resources/data/allthemodium/patchouli_books/allthemodium/en_us/entries/dimensions/teleport_pad.json
@@ -9,7 +9,7 @@
         },
         {
             "type": "text",
-            "text": "The Teleport Pad is used to teleport to $(l:dimensions/miningdim)The Mining Dimension$(/c), and $(l:dimensions/otherdim)The Other$(/c) you need to shift right click with both an empty hand and off hand."
+            "text": "The Teleport Pad is used to teleport to $(l:dimensions/miningdim)The Mining Dimension$(/c), and $(l:dimensions/otherdim)The Other$(/c) you need to shift right click with both an empty hand and off hand.$(br2)As a note, the $(l:dimensions/miningdim)The Mining Dimension$(/c) is disabled in the ATM6: To The Sky pack"
         }
     ]
 }


### PR DESCRIPTION
update to show mining dim is disabled in ATM6S

![image](https://user-images.githubusercontent.com/68764896/110585271-930d2600-813e-11eb-9277-12bfae766d42.png)
