### PR TITLE
Update biome colors in The Beyond

### DIFF
--- a/src/main/resources/data/allthemodium/worldgen/biome/the_beyond.json
+++ b/src/main/resources/data/allthemodium/worldgen/biome/the_beyond.json
@@ -3,8 +3,8 @@
   "downfall": 0,
   "has_precipitation": false,
   "effects": {
-    "sky_color": 0,
-    "fog_color": 0,
+    "sky_color": 8180453,
+    "fog_color": 12638463,
     "water_color": 4159204,
     "water_fog_color": 329011,
     "grass_color": 9551193,


### PR DESCRIPTION
This change adds biome sky color and fog color to The Beyond so that shaders like the included complimentary reimagined can better render the dimension. It makes the shadows less harsh, bringing it more inline with the overworld. Below are before and after screenshots. 
![2024-09-07_13 09 12](https://github.com/user-attachments/assets/33580fde-8ce7-41da-8cd8-5faf12e919a6)
![2024-09-07_13 08 54](https://github.com/user-attachments/assets/9d67b7da-4342-4d66-96c6-7f763dd17d2d)
