### PR TITLE
feat: refactor teleport pad

### DIFF
--- a/src/generated/resources/data/allthemodium/loot_table/blocks/teleport_pad.json
+++ b/src/generated/resources/data/allthemodium/loot_table/blocks/teleport_pad.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "allthemodium:teleport_pad"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "allthemodium:blocks/teleport_pad"
+}

--- a/src/main/java/com/thevortex/allthemodium/AllTheModium.java
+++ b/src/main/java/com/thevortex/allthemodium/AllTheModium.java
@@ -95,6 +95,7 @@ public class AllTheModium
     	//ATMCraftingSetup.REGISTRY.register(modEventBus);
 		ATMStructures.STRUCTURES.register(modEventBus);
 		ModRegistry.FEATURES.register(modEventBus);
+		ModRegistry.POI_TYPES.register(modEventBus);
 		ModRegistry.CREATIVE_TABS.register(modEventBus);
 		
 

--- a/src/main/java/com/thevortex/allthemodium/blocks/TeleportPad.java
+++ b/src/main/java/com/thevortex/allthemodium/blocks/TeleportPad.java
@@ -1,38 +1,58 @@
 package com.thevortex.allthemodium.blocks;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import com.mojang.serialization.MapCodec;
-import com.thevortex.allthemodium.AllTheModium;
 
-import com.thevortex.allthemodium.reference.Reference;
 import com.thevortex.allthemodium.registry.LevelRegistry;
 import com.thevortex.allthemodium.registry.ModRegistry;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.ai.village.poi.PoiManager;
+import net.minecraft.world.entity.ai.village.poi.PoiRecord;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.border.WorldBorder;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+
+import org.jetbrains.annotations.Nullable;
 
 public class TeleportPad extends Block {
 	MapCodec<? extends TeleportPad> codec = simpleCodec(TeleportPad::new);
 	
 	protected static final VoxelShape TELEPORTPAD_AABB = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 3.0D, 16.0D);
 
+	public static final BooleanProperty SPAWNED = BooleanProperty.create("spawned");
+
 	public TeleportPad(Properties properties) {
+		this(false, properties);
+	}
+
+	public TeleportPad(boolean spawned, Properties properties) {
 		super(properties);
-		// TODO Auto-generated constructor stub
+		this.registerDefaultState(this.stateDefinition.any().setValue(SPAWNED, spawned));
+	}
+
+	@Override
+	protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+		builder.add(SPAWNED);
 	}
 
 	@Override
@@ -40,19 +60,14 @@ public class TeleportPad extends Block {
 		return TELEPORTPAD_AABB;
 	}
 
-
-
 	@Override
-	public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos,
-			CollisionContext context) {
-
+	public VoxelShape getCollisionShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
 		return TELEPORTPAD_AABB;
 	}
 
 	@Override
-	public InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player,
-	BlockHitResult hitResult) {
-		if ((player instanceof ServerPlayer) && (player.isCrouching() == true)) {
+	public InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+		if ((player instanceof ServerPlayer) && (player.isCrouching())) {
 
 			transferPlayer((ServerPlayer) player, pos);
 			level.addAlwaysVisibleParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY() + 1, pos.getZ(), 0, 1, 0);
@@ -62,164 +77,143 @@ public class TeleportPad extends Block {
 
 	@Override
 	public boolean canHarvestBlock(BlockState state, BlockGetter world, BlockPos pos, Player player) {
-		if(player.level().dimension().registry().getNamespace().contains(Reference.MOD_ID)) {
-			return false;
-		} else {
-			return true;
-		}
+		return !state.getValue(SPAWNED);
 	}
 
 	public void transferPlayer(ServerPlayer player, BlockPos pos) {
 		int config = 1;//TweakProxy.packMode();
-		if (player.level().dimension().equals(LevelRegistry.Mining)) {
-			ServerLevel targetWorld = player.server.getLevel(AllTheModium.OverWorld);
-			int y = 256;
-			boolean located = false;
-			while (y >= 1) {
-				BlockPos posa = new BlockPos(Math.round(pos.getX()), y, Math.round(pos.getZ()));
-				Block potential = targetWorld.getBlockState(posa).getBlock();
-				if (potential.getName().toString().contains("teleport_pad")) {
-					located = true;
-					break;
 
-				} else {
-					y--;
-				}
-			}
-			if (located) {
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, pos.getX() + 0.5D, y + 0.25D, pos.getZ() + 0.5D, player.rotA,
-						player.yya);
+		// We can ignore the Warning here since if getPartner returns null, targetLevel will just be null and we return
+		@SuppressWarnings("ConstantConditions")
+		ServerLevel targetLevel = player.server.getLevel(getPartner(player.level().dimension(), config));
+		if (targetLevel == null) return;
 
-				return;
-			} else {
+		BlockPos targetPos = findSafeExit(targetLevel, pos);
+		teleport(player, targetLevel, targetPos);
+	}
 
-				if ((!targetWorld.getBlockState(pos).hasBlockEntity())
-						&& (targetWorld.getBlockState(pos).canEntityDestroy(targetWorld, pos, player))) {
-					//targetWorld.setBlockState(pos, ModBlocks.TELEPORT_PAD.getDefaultState());
-				}
-
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, pos.getX() + 0.5D, pos.getY() + 0.25D, pos.getZ() + 0.5D, player.rotA,
-						player.yya);
-			}
-
+	/// Somewhat mirrors {@link net.minecraft.world.level.portal.PortalForcer#createPortal}
+	private BlockPos findSafeExit(ServerLevel level, BlockPos entryPos) {
+		// Look for an existing portal
+		Optional<BlockPos> existing = findClosestTeleportPad(
+				level, entryPos, 32, level.getWorldBorder()
+		);
+		if (existing.isPresent()) {
+			return existing.get();
 		}
-		else if (player.level().dimension().equals(AllTheModium.Nether)) {
-			ServerLevel targetWorld = player.server.getLevel(LevelRegistry.THE_OTHER);
-			BlockPos targetPos = new BlockPos(Math.round(pos.getX()), Math.round(pos.getY()), Math.round(pos.getZ()));
 
-			if (!targetWorld.getBlockState(targetPos).hasBlockEntity()) {
+		// Look for a safe spot in the world
+		for (BlockPos.MutableBlockPos candidate : BlockPos.spiralAround(entryPos, 32, Direction.EAST, Direction.SOUTH)) {
+			if (!level.getWorldBorder().isWithinBounds(candidate)) continue;
 
-				LevelHeightAccessor accessor = targetWorld.getChunk(pos).getHeightAccessorForGeneration();
-				int y = targetWorld.getChunkSource().getGenerator().getSpawnHeight(accessor);
-				targetWorld.setBlockAndUpdate(new BlockPos(targetPos.getX(),y,targetPos.getZ()), ModRegistry.TELEPORT_PAD.get().defaultBlockState());
-
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, targetPos.getX() + 0.5D, y + 0.25D, targetPos.getZ() + 0.5D, 0, 0);
-
-
+			int y = level.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, candidate.getX(), candidate.getZ());
+			if(level.dimensionType().hasCeiling()){
+				y = findSafeY(level, candidate.getX(), y, candidate.getZ(), candidate);
 			}
-		}
-		
-		else if (player.level().dimension().equals(LevelRegistry.THE_OTHER)) {
-			ServerLevel targetWorld = player.server.getLevel(AllTheModium.Nether);
-			int y = 128;
-			boolean located = false;
-			while (y >= 1) {
-				BlockPos posa = new BlockPos(Math.round(pos.getX()), y, Math.round(pos.getZ()));
-				Block potential = targetWorld.getBlockState(posa).getBlock();
-				if (potential.getName().toString().contains("teleport_pad")) {
-					located = true;
-					break;
 
-				} else {
-					y--;
-				}
-			}
-			if (located) {
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, pos.getX() + 0.5D, y + 0.25D, pos.getZ() + 0.5D, player.rotA,
-						player.yya);
-
-				return;
-			} else {
-				BlockPos newpos = new BlockPos(pos.getX(), 90 , pos.getZ());
-				if ((!targetWorld.getBlockState(newpos).hasBlockEntity())
-						&& (targetWorld.getBlockState(newpos).canEntityDestroy(targetWorld, newpos, player))) {
-					targetWorld.setBlockAndUpdate(newpos, ModRegistry.TELEPORT_PAD.get().defaultBlockState());
-				}
-
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, newpos.getX(), newpos.getY(), newpos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, newpos.getX() + 0.5D, newpos.getY() + 0.25D, newpos.getZ() + 0.5D, player.rotA,
-						player.yya);
-
-			}
-		} 
-		else if (player.level().dimension().equals(AllTheModium.The_End)) {
-			ServerLevel targetWorld = player.server.getLevel(LevelRegistry.THE_BEYOND);
-			BlockPos targetPos = new BlockPos(Math.round(pos.getX() *50), Math.round(pos.getY()), Math.round(pos.getZ()*50));
-
-			if (!targetWorld.getBlockState(targetPos).hasBlockEntity()) {
-
-				LevelHeightAccessor accessor = targetWorld.getChunk(pos).getHeightAccessorForGeneration();
-				int y = targetWorld.getChunkSource().getGenerator().getSpawnHeight(accessor);
-				targetWorld.setBlockAndUpdate(new BlockPos(targetPos.getX(),y,targetPos.getZ()), ModRegistry.TELEPORT_PAD.get().defaultBlockState());
-				if(targetWorld.getBlockState(new BlockPos(targetPos.getX(),y-1,targetPos.getZ())).is(Blocks.AIR)){
-					targetWorld.setBlockAndUpdate(new BlockPos(targetPos.getX(),y-1,targetPos.getZ()), ModRegistry.ANCIENT_POLISHED_STONE.get().defaultBlockState());
-				}
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, targetPos.getX() + 0.5D, y + 0.25D, targetPos.getZ() + 0.5D, 0, 0);
-
-
-			}
-		}
-		else if (player.level().dimension().equals(LevelRegistry.THE_BEYOND)) {
-			ServerLevel targetWorld = player.server.getLevel(AllTheModium.The_End);
-			int y = 384;
-			boolean located = false;
-			while (y >= -63) {
-				BlockPos posa = new BlockPos(Math.round(pos.getX()/50), y, Math.round(pos.getZ())/50);
-				Block potential = targetWorld.getBlockState(posa).getBlock();
-				if (potential.getName().toString().contains("teleport_pad")) {
-					located = true;
-					break;
-
-				} else {
-					y--;
-				}
-			}
-			if (located) {
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, pos.getX()/50 + 0.5D, y + 0.25D, pos.getZ()/50 + 0.5D, player.rotA,
-						player.yya);
-
-				return;
-			} else {
-				BlockPos newpos = new BlockPos(pos.getX()/50, 90 , pos.getZ()/50);
-				if ((!targetWorld.getBlockState(newpos).hasBlockEntity())
-						&& (targetWorld.getBlockState(newpos).canEntityDestroy(targetWorld, newpos, player))) {
-					targetWorld.setBlockAndUpdate(newpos, ModRegistry.TELEPORT_PAD.get().defaultBlockState());
-				}
-
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, newpos.getX(), newpos.getY(), newpos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, newpos.getX() + 0.5D, newpos.getY() + 0.25D, newpos.getZ() + 0.5D, player.rotA,
-						player.yya);
-
-			}
-		}
-		else if (player.level().dimension().equals(AllTheModium.OverWorld) && (config != 5)) {
-			ServerLevel targetWorld = player.server.getLevel(LevelRegistry.Mining);
-			BlockPos targetPos = new BlockPos(Math.round(pos.getX()), 253, Math.round(pos.getZ()));
-			if (!targetWorld.getBlockState(targetPos).hasBlockEntity()) {
-				targetWorld.setBlockAndUpdate(targetPos, ModRegistry.TELEPORT_PAD.get().defaultBlockState());
-				targetWorld.addParticle(ParticleTypes.SOUL_FIRE_FLAME, pos.getX(), pos.getY(), pos.getZ(), 0, 1, 0);
-				player.teleportTo(targetWorld, targetPos.getX() + 0.5D, targetPos.getY() + 0.25D, targetPos.getZ() + 0.5D, 0, 0);
-
+			BlockPos spot = new BlockPos(candidate.getX(), y, candidate.getZ());
+			if (isSafeSpot(level, spot)) {
+				level.setBlockAndUpdate(spot, ModRegistry.TELEPORT_PAD.get().defaultBlockState().setValue(SPAWNED, true));
+				return spot;
 			}
 		}
 
+		// Use the original position if no safe spot was found
+		level.setBlockAndUpdate(entryPos, ModRegistry.TELEPORT_PAD.get().defaultBlockState().setValue(SPAWNED, true));
+		return entryPos;
+	}
+
+	// Go down until we find a safe spot or the bottom of the world, in which case we return the spawn height
+	private int findSafeY(ServerLevel level, int x, int y, int z, BlockPos.MutableBlockPos pos) {
+		int minY = level.getMinBuildHeight();
+		pos.set(x, y - 1, z);
+		pos.move(Direction.DOWN);
+
+		while (pos.getY() > minY) {
+			if (isSafeSpot(level, pos.immutable())) {
+				return pos.getY();
+			}
+			pos.move(Direction.DOWN);
+		}
+
+		return level.getChunkSource().getGenerator().getSpawnHeight(level.getChunk(pos).getHeightAccessorForGeneration());
 	}
 
 
+	// A safe spot is a 1x2 box of air with a solid ground
+	private boolean isSafeSpot(ServerLevel level, BlockPos pos) {
+		BlockState here  = level.getBlockState(pos);
+		FluidState hereFluid = level.getFluidState(pos);
+		BlockState below = level.getBlockState(pos.below());
+		FluidState belowFluid = level.getFluidState(pos.below());
+		BlockState above = level.getBlockState(pos.above());
+		FluidState aboveFluid = level.getFluidState(pos.above());
+
+		return ((here.isAir() || here.is(BlockTags.REPLACEABLE)) && hereFluid.isEmpty()) &&
+				((above.isAir() || above.is(BlockTags.REPLACEABLE)) && aboveFluid.isEmpty()) &&
+				(!(below.isAir() || below.is(BlockTags.REPLACEABLE) || below.is(Blocks.BEDROCK)) && belowFluid.isEmpty());
+	}
+
+	/// Stolen from {@link net.minecraft.world.level.portal.PortalForcer#findClosestPortalPosition}
+	public Optional<BlockPos> findClosestTeleportPad(
+			ServerLevel level,
+			BlockPos origin,
+			int radius,
+			WorldBorder border
+	) {
+		PoiManager poiManager = level.getPoiManager();
+		poiManager.ensureLoadedAndValid(level, origin, radius);
+
+		return poiManager.getInSquare(
+						record -> record.is(ModRegistry.TELEPORT_PAD_POI),
+						origin,
+						radius,
+						PoiManager.Occupancy.ANY
+				)
+				.map(PoiRecord::getPos)
+				.filter(border::isWithinBounds)
+				.filter(pos -> level.getBlockState(pos).is(ModRegistry.TELEPORT_PAD))
+				.min(Comparator.<BlockPos>
+						comparingDouble(pos -> pos.distSqr(origin))
+						.thenComparingInt(Vec3i::getY)
+				);
+	}
+
+	private void teleport(ServerPlayer player, ServerLevel level, BlockPos targetPos) {
+		level.addParticle(ParticleTypes.SOUL_FIRE_FLAME, targetPos.getX(), targetPos.getY(), targetPos.getZ(), 0, 1, 0);
+		player.teleportTo(level, targetPos.getX() + 0.5D, targetPos.getY() + 0.25D, targetPos.getZ() + 0.5D, player.rotA, player.yya);
+	}
+
+	private @Nullable ResourceKey<Level> getPartner(ResourceKey<Level> level, int packMode) {
+		Map<ResourceKey<Level>, ResourceKey<Level>> map = OVERRIDES.getOrDefault(packMode, DEFAULT_PARTNERS);
+        return map.get(level);
+	}
+
+	public record LevelPair(ResourceKey<Level> a, ResourceKey<Level> b) {}
+
+	private static Map<ResourceKey<Level>, ResourceKey<Level>> buildMap(LevelPair... pairs) {
+		Map<ResourceKey<Level>, ResourceKey<Level>> m = new HashMap<>();
+		// Bidirectional
+		for (var p : pairs) {
+			m.put(p.a, p.b);
+			m.put(p.b, p.a);
+		}
+		return m;
+	}
+
+	private static final Map<ResourceKey<Level>,ResourceKey<Level>> DEFAULT_PARTNERS =
+			buildMap(
+					new LevelPair(ServerLevel.OVERWORLD, LevelRegistry.Mining),
+					new LevelPair(ServerLevel.NETHER,    LevelRegistry.THE_OTHER),
+					new LevelPair(ServerLevel.END,       LevelRegistry.THE_BEYOND)
+			);
+
+	// Used for special pairs in individual pack modes
+	private static final Map<Integer, Map<ResourceKey<Level>,ResourceKey<Level>>> OVERRIDES = Map.of(
+			/*
+			[packmode], buildMap(
+					new LevelPair(SomeDimension, SomeOtherDimension)
+			);
+			*/
+	);
 }

--- a/src/main/java/com/thevortex/allthemodium/datagen/server/ATMLootTables.java
+++ b/src/main/java/com/thevortex/allthemodium/datagen/server/ATMLootTables.java
@@ -12,7 +12,7 @@ import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
 import net.neoforged.neoforge.registries.DeferredHolder;
 
-import java.util.Collection;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -68,7 +68,7 @@ public class ATMLootTables extends VanillaBlockLoot {
 
         @Override
         protected Iterable<Block> getKnownBlocks() {
-            return Stream.of(ModRegistry.BLOCKS.getEntries(),
+            List<Block> list = Stream.of(ModRegistry.BLOCKS.getEntries(),
                     ModRegistry.STAIRBLOCKS.getEntries(),
                     ModRegistry.SLABBLOCKS.getEntries(),
                     ModRegistry.WALLBLOCKS.getEntries(),
@@ -77,7 +77,8 @@ public class ATMLootTables extends VanillaBlockLoot {
                     .flatMap(Collection::stream)
                     .map(DeferredHolder::get)
                     .collect(Collectors.toList());
-
+            list.add(ModRegistry.TELEPORT_PAD.get());
+            return list;
         }
         protected Iterable<Block> getKnownStairs() {
             return ModRegistry.STAIRBLOCKS.getEntries()

--- a/src/main/java/com/thevortex/allthemodium/registry/ModRegistry.java
+++ b/src/main/java/com/thevortex/allthemodium/registry/ModRegistry.java
@@ -1,5 +1,6 @@
 package com.thevortex.allthemodium.registry;
 
+import com.google.common.collect.ImmutableSet;
 import com.thevortex.allthemodium.blocks.*;
 import com.thevortex.allthemodium.blocks.entity.ATMBrushableBlockEntity;
 import com.thevortex.allthemodium.init.ModFoods;
@@ -28,6 +29,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
 import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
@@ -64,8 +66,8 @@ public class ModRegistry {
 	public static final DeferredRegister<Block> WALLBLOCKS = DeferredRegister.createBlocks(Reference.MOD_ID);
 	public static final DeferredRegister<Block> SLABBLOCKS = DeferredRegister.createBlocks(Reference.MOD_ID);
 	public static final DeferredRegister<Block> PILLARBLOCKS = DeferredRegister.createBlocks(Reference.MOD_ID);
-	public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(Registries.BIOME,
-			Reference.MOD_ID);
+	public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(Registries.BIOME, Reference.MOD_ID);
+	public static final DeferredRegister<PoiType> POI_TYPES = DeferredRegister.create(Registries.POINT_OF_INTEREST_TYPE, Reference.MOD_ID);
 
 	public static final DeferredRegister<Item> ITEMS = DeferredRegister.createItems(Reference.MOD_ID);
 
@@ -88,9 +90,11 @@ public class ModRegistry {
 
 	public static final DeferredHolder<Biome,Biome> MINING = BIOMES.register("mining", () -> ATMBiomes.mining());
 	
-	//
+	// POI TYPES
 
-
+	public static final DeferredHolder<PoiType, PoiType> TELEPORT_PAD_POI = POI_TYPES.register("teleport_pad",
+			() -> new PoiType(ImmutableSet.copyOf(ModRegistry.TELEPORT_PAD.get().getStateDefinition().getPossibleStates()), 1, 1)
+	);
 
 	// FOOD
 
@@ -406,7 +410,7 @@ public class ModRegistry {
 
 
 
-	public static final DeferredHolder<Block,Block> TELEPORT_PAD = SHAPED_BLOCKS.register("teleport_pad", () -> new TeleportPad(Block.Properties.of().noLootTable().noOcclusion().strength(20.0F)));
+	public static final DeferredHolder<Block,Block> TELEPORT_PAD = SHAPED_BLOCKS.register("teleport_pad", () -> new TeleportPad(Block.Properties.of().noOcclusion().strength(20.0F)));
 	public static final DeferredHolder<Item,Item> TELEPORT_PAD_ITEM = ITEMS.register("teleport_pad", () -> new BlockItem(TELEPORT_PAD.get(), new Item.Properties()));
 
 	


### PR DESCRIPTION
- cleaner code
- uses POI to look for existing portals before spawning a new one
- looks for empty space in a radius instead of only on one axis
- only player-placed portals will drop