### PR TITLE
Fix piglich crash on servers

### DIFF
--- a/src/generated/resources/assets/allthemodium/lang/en_us.json
+++ b/src/generated/resources/assets/allthemodium/lang/en_us.json
@@ -104,6 +104,8 @@
   "dimension.allthemodium.mining": "Mining Dimension",
   "dimension.allthemodium.the_beyond": "The Beyond",
   "dimension.allthemodium.the_other": "The Other",
+  "entity.allthemodium.alloy_trident": "Allthemodium Alloy Trident",
+  "entity.allthemodium.piglich": "Piglich",
   "item.allthemodium.alloy_axe": "Allthemodium Alloy Axe",
   "item.allthemodium.alloy_mace": "Allthemodium Alloy Mace",
   "item.allthemodium.alloy_paxel": "Allthemodium Alloy Paxel",

--- a/src/main/java/net/allthemods/allthemodium/common/entity/PiglichEntity.java
+++ b/src/main/java/net/allthemods/allthemodium/common/entity/PiglichEntity.java
@@ -186,6 +186,8 @@ public class PiglichEntity extends Piglin implements GeoEntity {
             if (support == null) continue;
             
             BlockPos pos = this.findSupportSpawnPos(level, support, entityType, origin);
+            if (pos == null) continue;
+            
             if (!this.canSpawnSupport(level, support, entityType, pos)) continue;
             
             support.setTarget(target);

--- a/src/main/java/net/allthemods/allthemodium/data/provider/ATMLanguageProvider.java
+++ b/src/main/java/net/allthemods/allthemodium/data/provider/ATMLanguageProvider.java
@@ -7,6 +7,7 @@ import net.minecraft.data.PackOutput;
 import net.allthemods.allthemodium.api.ATM;
 import net.allthemods.allthemodium.client.lang.ATMLanguage;
 import net.allthemods.allthemodium.core.registry.ATMBlocks;
+import net.allthemods.allthemodium.core.registry.ATMEntities;
 import net.allthemods.allthemodium.core.registry.ATMFluids;
 import net.allthemods.allthemodium.core.registry.ATMItems;
 import net.allthemods.allthemodium.data.worldgen.ATMDimensions;
@@ -22,6 +23,9 @@ public class ATMLanguageProvider extends LanguageProvider {
         this.addBlocks();
         this.addItems();
         this.addTrimMaterials();
+        
+        this.addEntityType(ATMEntities.PIGLICH, "Piglich");
+        this.addEntityType(ATMEntities.ALLOY_TRIDENT_ENTITY, "Allthemodium Alloy Trident");
         
         this.addDimension(ATMDimensions.MINING, "Mining Dimension");
         this.addDimension(ATMDimensions.THE_BEYOND, "The Beyond");


### PR DESCRIPTION
@thevortex the ATO hammer duping seems to be an ATM11 specific issue because it's not recreatable in dev

### ATM11
<img width="840" height="386" alt="image" src="https://github.com/user-attachments/assets/568fa155-97f9-4abb-88fc-5ab4551b2bc4" />

### DEV
<img width="1005" height="459" alt="2026-04-23-170244_hyprshot" src="https://github.com/user-attachments/assets/bae221f7-05c3-4b8a-ab18-4f4d12b1ab6e" />
